### PR TITLE
bump: flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -157,11 +157,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759236626,
-        "narHash": "sha256-1BjCUU2csqhR5umGYFnOOTU8r8Bi+bnB2SLsr0FLcws=",
+        "lastModified": 1759261733,
+        "narHash": "sha256-G104PUPKBgJmcu4NWs0LUaPpSOTD4jiq4mamLWu3Oc0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9e0453a9b0c8ef22de0355b731d712707daa6308",
+        "rev": "5a21f4819ee1be645f46d6b255d49f4271ef6723",
         "type": "github"
       },
       "original": {
@@ -279,11 +279,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1758896330,
-        "narHash": "sha256-YAg2kMOxwBeQKZwX28+v1/VTSCx2X2w41qbIA33pzio=",
+        "lastModified": 1759289070,
+        "narHash": "sha256-OBTW4XQk8O101DSELvOYEkDlymKA68i886kGj90tE4U=",
         "owner": "CnTeng",
         "repo": "ph",
-        "rev": "7da96cd6cdd869610eefc86753b2a89dfbbe6460",
+        "rev": "04d0e2f01dd1b343472464b5fdca167b03955410",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated changes by GitHub Action.

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/9e0453a9b0c8ef22de0355b731d712707daa6308?narHash=sha256-1BjCUU2csqhR5umGYFnOOTU8r8Bi%2BbnB2SLsr0FLcws%3D' (2025-09-30)
  → 'github:nix-community/home-manager/5a21f4819ee1be645f46d6b255d49f4271ef6723?narHash=sha256-G104PUPKBgJmcu4NWs0LUaPpSOTD4jiq4mamLWu3Oc0%3D' (2025-09-30)
• Updated input 'ph':
    'github:CnTeng/ph/7da96cd6cdd869610eefc86753b2a89dfbbe6460?narHash=sha256-YAg2kMOxwBeQKZwX28%2Bv1/VTSCx2X2w41qbIA33pzio%3D' (2025-09-26)
  → 'github:CnTeng/ph/04d0e2f01dd1b343472464b5fdca167b03955410?narHash=sha256-OBTW4XQk8O101DSELvOYEkDlymKA68i886kGj90tE4U%3D' (2025-10-01)
```