### PR TITLE
bump: flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -94,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758108966,
-        "narHash": "sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo=",
+        "lastModified": 1759523803,
+        "narHash": "sha256-PTod9NG+i3XbbnBKMl/e5uHDBYpwIWivQ3gOWSEuIEM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "54df955a695a84cd47d4a43e08e1feaf90b1fd9b",
+        "rev": "cfc9f7bb163ad8542029d303e599c0f7eee09835",
         "type": "github"
       },
       "original": {
@@ -157,11 +157,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759337100,
-        "narHash": "sha256-CcT3QvZ74NGfM+lSOILcCEeU+SnqXRvl1XCRHenZ0Us=",
+        "lastModified": 1759573136,
+        "narHash": "sha256-ILSPD0Dm8p0w0fCVzOx98ZH8yFDrR75GmwmH3fS2VnE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "004753ae6b04c4b18aa07192c1106800aaacf6c3",
+        "rev": "5f06ceafc6c9b773a776b9195c3f47bbe1defa43",
         "type": "github"
       },
       "original": {
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759298269,
-        "narHash": "sha256-ZNCJ+XVOH9rZ+ACamzfoTKOdBzbwfl8zsDrD9NnL41g=",
+        "lastModified": 1759525625,
+        "narHash": "sha256-PFG/zIN+eG7iEDw24LQ1ZVNaMqHVpdSZC4FnE+cZLes=",
         "owner": "CnTeng",
         "repo": "rx-nvim",
-        "rev": "bb0291fec0084f6508c171b09d333a95a7632f58",
+        "rev": "a8e35851edde5bcb5b8a37d9207ac8b57b73e989",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated changes by GitHub Action.

```
Flake lock file updates:

• Updated input 'git-hooks-nix':
    'github:cachix/git-hooks.nix/54df955a695a84cd47d4a43e08e1feaf90b1fd9b?narHash=sha256-ytw7ROXaWZ7OfwHrQ9xvjpUWeGVm86pwnEd1QhzawIo%3D' (2025-09-17)
  → 'github:cachix/git-hooks.nix/cfc9f7bb163ad8542029d303e599c0f7eee09835?narHash=sha256-PTod9NG%2Bi3XbbnBKMl/e5uHDBYpwIWivQ3gOWSEuIEM%3D' (2025-10-03)
• Updated input 'home-manager':
    'github:nix-community/home-manager/004753ae6b04c4b18aa07192c1106800aaacf6c3?narHash=sha256-CcT3QvZ74NGfM%2BlSOILcCEeU%2BSnqXRvl1XCRHenZ0Us%3D' (2025-10-01)
  → 'github:nix-community/home-manager/5f06ceafc6c9b773a776b9195c3f47bbe1defa43?narHash=sha256-ILSPD0Dm8p0w0fCVzOx98ZH8yFDrR75GmwmH3fS2VnE%3D' (2025-10-04)
• Updated input 'rx-nvim':
    'github:CnTeng/rx-nvim/bb0291fec0084f6508c171b09d333a95a7632f58?narHash=sha256-ZNCJ%2BXVOH9rZ%2BACamzfoTKOdBzbwfl8zsDrD9NnL41g%3D' (2025-10-01)
  → 'github:CnTeng/rx-nvim/a8e35851edde5bcb5b8a37d9207ac8b57b73e989?narHash=sha256-PFG/zIN%2BeG7iEDw24LQ1ZVNaMqHVpdSZC4FnE%2BcZLes%3D' (2025-10-03)
```